### PR TITLE
Build and portability fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,7 @@ AC_CONFIG_HEADER([config.h])
 AC_PROG_CC
 
 # Checks for libraries.
+AC_CHECK_LIB([m], [pow], ,AC_MSG_ERROR([Cannot find math library]))
 AC_CHECK_LIB([gsm], [gsm_create], ,AC_MSG_ERROR([Cannot find gsm library]))
 AC_CHECK_LIB([sndfile], [sf_open], ,AC_MSG_ERROR([Cannot find sndfile library]))
 AC_CHECK_LIB([speex], [speex_encoder_init], ,AC_MSG_ERROR([Cannot find speex library]))
@@ -19,7 +20,7 @@ AC_CHECK_LIB([pcap], [pcap_next], ,AC_MSG_ERROR([Cannot find pcap library]))
 
 # Checks for header files.
 AC_HEADER_STDC
-AC_CHECK_HEADERS([arpa/inet.h stdlib.h string.h strings.h sys/time.h unistd.h])
+AC_CHECK_HEADERS([arpa/inet.h stdlib.h string.h strings.h sys/time.h unistd.h gsm.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/src/contrib/in_cksum.c
+++ b/src/contrib/in_cksum.c
@@ -35,6 +35,8 @@
  *
  *	@(#)in_cksum.c	8.1 (Berkeley) 6/10/93
  */
+#include <arpa/inet.h>
+
 #include "in_cksum.h"
 
 /*

--- a/src/contrib/iniparser.c
+++ b/src/contrib/iniparser.c
@@ -763,12 +763,14 @@ int iniparser_getpositiveint(dictionary * d, char * key, int notfound)
 {
     int value = iniparser_getint(d, key, notfound);
     if (value <= 0) return notfound;
+    return value;
 }
 
 int iniparser_getnonnegativeint(dictionary * d, char * key, int notfound)
 {
     int value = iniparser_getint(d, key, notfound);
     if (value < 0) return notfound;
+    return value;
 }
 
 /*-------------------------------------------------------------------------*/

--- a/src/gamma_delay_filter.c
+++ b/src/gamma_delay_filter.c
@@ -33,6 +33,7 @@
  *
  */
 #include "contrib/ranlib/ranlib.h"
+#include "misc.h"
 #include "gamma_delay_filter.h"
 
 

--- a/src/gsm_codec.h
+++ b/src/gsm_codec.h
@@ -34,7 +34,13 @@
  */
 #ifndef __GSM_CODEC_H
 #define __GSM_CODEC_H
+
+#include "config.h"
+#if HAVE_GSM_H
+#include <gsm.h>
+#else
 #include <gsm/gsm.h>
+#endif
 
 #include "codecapi.h"
 

--- a/src/log_filter.c
+++ b/src/log_filter.c
@@ -68,12 +68,12 @@ wr_errorcode_t wr_log_filter_notify(wr_rtp_filter_t * filter, wr_event_type_t ev
                     timersub(&state->prev_timestamp, &packet->lowlevel_timestamp, &timediff);
                     diffsign = '-';
                 }
-                snprintf(diff, 256, "%c%ld.%06ld", diffsign, timediff.tv_sec, timediff.tv_usec);
+                snprintf(diff, 256, "%c%ld.%06ld", diffsign, timediff.tv_sec, (long)timediff.tv_usec);
             }
             
             printf("%ld.%06ld\t%s\t%d\t%d\t%d\n", 
                 packet->lowlevel_timestamp.tv_sec, 
-                packet->lowlevel_timestamp.tv_usec, 
+                (long)packet->lowlevel_timestamp.tv_usec, 
                 diff, 
                 packet->sequence_number,
                 packet->rtp_timestamp, 

--- a/src/misc.h
+++ b/src/misc.h
@@ -35,6 +35,8 @@
 #ifndef __WR_MISC_H
 #define __WR_MISC_H
 
+#include <sys/time.h>
+
 /** @defgroup misc miscellaneous
  *  Miscellaneous helper functions 
  *  @{

--- a/src/rtpapi.c
+++ b/src/rtpapi.c
@@ -46,6 +46,7 @@ int wr_rtp_packet_init(wr_rtp_packet_t * rtp_packet, int payload_type, int seque
     rtp_packet->lowlevel_timestamp.tv_usec = lowlevel_timestamp.tv_usec;
     rtp_packet->markbit = markbit;
     list_init(&rtp_packet->data_frames);
+    return 0;
 }
 
 
@@ -104,6 +105,7 @@ wr_errorcode_t wr_rtp_packet_add_frame(wr_rtp_packet_t * packet, uint8_t * data,
 int wr_rtp_packet_delete_frame(wr_rtp_packet_t * packet, int position)
 {
     /* XXX: Not yet implemented */
+    return 0;
 }
 
 void wr_rtp_filter_create(wr_rtp_filter_t * filter, char *name, 
@@ -157,4 +159,5 @@ void wr_rtp_filter_notify_observers(wr_rtp_filter_t * filter, wr_event_type_t ev
 wr_errorcode_t wr_do_nothing_on_notify(wr_rtp_filter_t * filter, wr_event_type_t event, wr_rtp_packet_t * packet)
 {
     /* Do nothing ;-) */
+    return WR_OK;
 }

--- a/src/rtpmap.c
+++ b/src/rtpmap.c
@@ -32,6 +32,8 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
+#include <string.h>
+
 #include "rtpmap.h"
 
 

--- a/src/uniform_delay_filter.c
+++ b/src/uniform_delay_filter.c
@@ -33,6 +33,7 @@
  *
  */
 #include "contrib/ranlib/ranlib.h"
+#include "misc.h"
 #include "uniform_delay_filter.h"
 
 

--- a/src/wav2rtp.c
+++ b/src/wav2rtp.c
@@ -38,6 +38,8 @@
 #include "options.h"
 #include "error_types.h"
 
+#include "contrib/ranlib/ranlib.h"
+#include "misc.h"
 #include "rtpapi.h"
 #include "wavfile_filter.h"
 #include "dummy_filter.h"

--- a/src/wavfile_output_filter.c
+++ b/src/wavfile_output_filter.c
@@ -32,6 +32,7 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
+#include "misc.h"
 #include "options.h"
 #include "rtpmap.h"
 #include "wavfile_output_filter.h"

--- a/src/wavfile_output_filter.h
+++ b/src/wavfile_output_filter.h
@@ -32,7 +32,7 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
-#ifndef WAVFIlE_OUTPUT_FILTER
+#ifndef WAVFILE_OUTPUT_FILTER
 #define WAVFILE_OUTPUT_FILTER
 #include <sndfile.h>
 #include "rtpapi.h"


### PR DESCRIPTION
- Builds on OSX now.
- Link math library for `pow`
- use portable `ether_aton` instead of `ether_aton_r`.  The reentrant version doesn't appear to be needed
- Use portable `struct ip` instead of `struct iphdr`
